### PR TITLE
Add error handleing for buffer object

### DIFF
--- a/AvaloniaSilkExample/Gl/BufferObject.cs
+++ b/AvaloniaSilkExample/Gl/BufferObject.cs
@@ -15,7 +15,10 @@ namespace Tutorial
         {
             _gl = gl;
             _bufferType = bufferType;
-            _gl.GetError();//Clear existing error code.
+            //Clear existing error code.
+            GLEnum error;
+            do error = _gl.GetError();
+            while (error != GLEnum.NoError);
             _handle = _gl.GenBuffer();
             Bind();
             GlErrorException.ThrowIfError(gl);

--- a/AvaloniaSilkExample/Gl/BufferObject.cs
+++ b/AvaloniaSilkExample/Gl/BufferObject.cs
@@ -1,3 +1,4 @@
+using AvaloniaSilkExample.Gl;
 using Silk.NET.OpenGL;
 using System;
 
@@ -14,13 +15,15 @@ namespace Tutorial
         {
             _gl = gl;
             _bufferType = bufferType;
-
+            _gl.GetError();//Clear existing error code.
             _handle = _gl.GenBuffer();
             Bind();
+            GlErrorException.ThrowIfError(gl);
             fixed (void* d = data)
             {
                 _gl.BufferData(bufferType, (nuint) (data.Length * sizeof(TDataType)), d, BufferUsageARB.StaticDraw);
             }
+            GlErrorException.ThrowIfError(gl);
         }
 
         public void Bind()

--- a/AvaloniaSilkExample/Gl/GlErrorException.cs
+++ b/AvaloniaSilkExample/Gl/GlErrorException.cs
@@ -1,0 +1,19 @@
+﻿using Silk.NET.OpenGL;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AvaloniaSilkExample.Gl {
+    public class GlErrorException : Exception {
+        public GlErrorException(string message) : base (message){ }
+
+        public static void ThrowIfError(GL Gl) {
+            GLEnum error = Gl.GetError();
+            if (error != GLEnum.NoError) {
+                throw new GlErrorException(error.ToString());
+            }
+        }
+    }
+}


### PR DESCRIPTION
I made my own program based on this example. But I went into trouble after I did some modification. Eventually, I found out that it was some error in OpenGL but since no error handling was there I can't get notified.
To make visual studio break on the exception, make sure you added `GlBindBufferToTexutreBufferBug.GlErrorException` to exception settings.